### PR TITLE
Add namespace filter

### DIFF
--- a/helm/kubernetes-external-dns-chart/templates/deployment.yaml
+++ b/helm/kubernetes-external-dns-chart/templates/deployment.yaml
@@ -42,6 +42,7 @@ spec:
         {{- end }}
         - --domain-filter={{ .Values.domainFilter }}
         - --metrics-address=:{{ .Values.metricsPort }}
+        - --namespace={{ .Values.namespace }}
         - --registry=txt
         - --txt-owner-id=giantswarm-io-external-dns
         readinessProbe:


### PR DESCRIPTION
There was feedback from Ubirch. They also run external-dns with Route53 backend.

This change adds additional restriction to our external-dns to only monitor services in kube-system namespace.

NOTE: I'm not bumping version, because we dont' have this deployed anywhere yet.